### PR TITLE
🐛 fix(react-notifications-discount): Remove final asterisk from disclaimer text.

### DIFF
--- a/packages/shared-notifications-discount/lib/shared-notifications-discount.js
+++ b/packages/shared-notifications-discount/lib/shared-notifications-discount.js
@@ -321,7 +321,7 @@ export class NoticeDiscount extends Component {
 					<Content>
 						{ this.props.children }
 						{ hasDisclaimer && (
-							<p className="sui-disclaimer">* { disclaimer } *</p>
+							<p className="sui-disclaimer">* { disclaimer }</p>
 						)}
 					</Content>
 


### PR DESCRIPTION
…text.