### PR TITLE
🐛 fix(shared-presets): Remove unused state and convert to functional component

### DIFF
--- a/packages/shared-presets/docs/presets-page-free.stories.js
+++ b/packages/shared-presets/docs/presets-page-free.stories.js
@@ -53,7 +53,7 @@ primary.argTypes = {
             type: 'text'
         }
     },
-	loading: {
+	isLoading: {
         type: {
             name: 'boolean',
             required: false

--- a/packages/shared-presets/docs/presets-page-pro.stories.js
+++ b/packages/shared-presets/docs/presets-page-pro.stories.js
@@ -55,7 +55,7 @@ primary.argTypes = {
             type: 'text'
         }
     },
-	loading: {
+	isLoading: {
         type: {
             name: 'boolean',
             required: false

--- a/packages/shared-presets/docs/presets-widget.stories.js
+++ b/packages/shared-presets/docs/presets-widget.stories.js
@@ -25,7 +25,7 @@ export const primary = Template.bind({});
 primary.storyName = "Default"
 primary.args = {
     title: 'Preset Configs',
-	loading: false,
+	isLoading: false,
 	loadingLabel: 'Updating the config list...',
     message: 'Configs bundle your Smush settings and make them available to download and apply on your other sites.',
     notice: 'You don’t have any available config. Save preset configurations of Smush’s settings, then upload and apply them to your other sites in just a few clicks!',

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -1,4 +1,4 @@
-import React, { Component, Children } from 'react';
+import React, { Children } from 'react';
 import { device, utils } from '../components/utils';
 import styled from 'styled-components';
 
@@ -7,126 +7,123 @@ import { Notifications } from '@wpmudev/react-notifications';
 import { Button } from '@wpmudev/react-button';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
-export class PresetsPage extends Component {
-    render() {
-        const { freeData, isLoading, children: configsList } = this.props,
-			isEmpty = ! configsList || 0 === configsList.length;
+export const PresetsPage = ( { freeData, isLoading, children: configsList, ...props } ) => {
+	const isEmpty = ! configsList || 0 === configsList.length;
 
-		const items = Children.map( configsList, item => (
-			<PresetsAccordionItem
-				id={ item.props.id }
-				default={ item.props.default || false }
-				title={ item.props.title }
-				description={ item.props.description }
-				image={ item.props.image }
-				showApplyButton={true}
-				applyLabel={ item.props.applyLabel }
-				applyAction={ item.props.applyAction }
-				downloadLabel={ item.props.downloadLabel }
-				downloadAction={ item.props.downloadAction }
-				editLabel={ item.props.editLabel }
-				editAction={ item.props.editAction }
-				deleteLabel={ item.props.deleteLabel }
-				deleteAction={ item.props.deleteAction }
-			>
-				{ item.props.children }
-			</PresetsAccordionItem>
-		) );
+	const items = Children.map( configsList, item => (
+		<PresetsAccordionItem
+			id={ item.props.id }
+			default={ item.props.default || false }
+			title={ item.props.title }
+			description={ item.props.description }
+			image={ item.props.image }
+			showApplyButton={true}
+			applyLabel={ item.props.applyLabel }
+			applyAction={ item.props.applyAction }
+			downloadLabel={ item.props.downloadLabel }
+			downloadAction={ item.props.downloadAction }
+			editLabel={ item.props.editLabel }
+			editAction={ item.props.editAction }
+			deleteLabel={ item.props.deleteLabel }
+			deleteAction={ item.props.deleteAction }
+		>
+			{ item.props.children }
+		</PresetsAccordionItem>
+	) );
 
-        return (
-            <Box>
+	return (
+		<Box>
 
-                <BoxHeader title={ this.props.title }>
-                    <div>
-                        <Button
-                            icon="upload-cloud"
-                            label={ this.props.uploadLabel || 'Upload' }
-                            design="ghost"
-							htmlFor="sui-upload-configs-input"
-                        />
-						<input
-							id="sui-upload-configs-input"
-							type="file"
-							name="config_file"
-							className="sui-hidden"
-							value=""
-							readOnly="readonly"
-							onChange={ this.props.uploadConfig }
-							accept=".json"
-						/>
-                        <Button
-                            icon="save"
-                            label={ this.props.saveLabel || 'Save Config' }
-                            color="blue"
-							onClick={ this.props.saveNewConfig }
-                        />
-                    </div>
-                </BoxHeader>
+			<BoxHeader title={ props.title }>
+				<div>
+					<Button
+						icon="upload-cloud"
+						label={ props.uploadLabel || 'Upload' }
+						design="ghost"
+						htmlFor="sui-upload-configs-input"
+					/>
+					<input
+						id="sui-upload-configs-input"
+						type="file"
+						name="config_file"
+						className="sui-hidden"
+						value=""
+						readOnly="readonly"
+						onChange={ props.uploadConfig }
+						accept=".json"
+					/>
+					<Button
+						icon="save"
+						label={ props.saveLabel || 'Save Config' }
+						color="blue"
+						onClick={ props.saveNewConfig }
+					/>
+				</div>
+			</BoxHeader>
 
-                <BoxBody>
+			<BoxBody>
 
-                    { this.props.description && (
-                        <p>{ this.props.description }</p>
-                    )}
+				{ props.description && (
+					<p>{ props.description }</p>
+				)}
 
-                    { ! isLoading && isEmpty && (
-                        <Notifications type="info">
-                            <p>{ this.props.empty }</p>
-                        </Notifications>
-                    )}
+				{ ! isLoading && isEmpty && (
+					<Notifications type="info">
+						<p>{ props.empty }</p>
+					</Notifications>
+				)}
 
-                </BoxBody>
+			</BoxBody>
 
-				{ isLoading && (
-					<div>
-						<span>
-							<span className="sui-icon-loader" aria-hidden="true"></span>
-							{ this.props.loadingLabel }
-						</span>
-					</div>
-				) }
+			{ isLoading && (
+				<div>
+					<span>
+						<span className="sui-icon-loader" aria-hidden="true"></span>
+						{ props.loadingLabel }
+					</span>
+				</div>
+			) }
 
-                { ! isEmpty && (
-                    <div
-                        className="sui-accordion sui-accordion-flushed"
-                        style={ {
-                            borderBottomWidth: 0
-                        } }
-                    >
-                        { items }
-                    </div>
-                )}
+			{ ! isEmpty && (
+				<div
+					className="sui-accordion sui-accordion-flushed"
+					style={ {
+						borderBottomWidth: 0
+					} }
+				>
+					{ items }
+				</div>
+			)}
 
-                { freeData && (
-                    <BoxFooter
-                        display="block"
-                    >
-                        <Notifications type="upsell">
-                            <p>{ freeData.message }</p>
-                            <p>
-                                <Button
-                                    label={ freeData.button || 'Try The Hub' }
-                                    color="purple"
-                                    href={ freeData.buttonHref || 'https://wpmudev.com/hub-welcome/' }
-                                    target="_blank"
-                                />
-                            </p>
-                        </Notifications>
-                    </BoxFooter>
-                )}
+			{ freeData && (
+				<BoxFooter
+					display="block"
+				>
+					<Notifications type="upsell">
+						<p>{ freeData.message }</p>
+						<p>
+							<Button
+								label={ freeData.button || 'Try The Hub' }
+								color="purple"
+								href={ freeData.buttonHref || 'https://wpmudev.com/hub-welcome/' }
+								target="_blank"
+							/>
+						</p>
+					</Notifications>
+				</BoxFooter>
+			)}
 
-                { this.props.update && (
-                    <BoxFooter
-                        display="block"
-                        alignment="center"
-                        paddingTop={ isEmpty ? 0 : 30 }
-                        border={ isEmpty ? 0 : 1 }
-                    >
-                        <p className="sui-description">{ this.props.update }</p>
-                    </BoxFooter>
-                )}
+			{ props.update && (
+				<BoxFooter
+					display="block"
+					alignment="center"
+					paddingTop={ isEmpty ? 0 : 30 }
+					border={ isEmpty ? 0 : 1 }
+				>
+					<p className="sui-description">{ props.update }</p>
+				</BoxFooter>
+			)}
 
-            </Box>
-        );
-    }
+		</Box>
+	);
 }

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -18,24 +18,18 @@ export class PresetsPage extends Component {
     }
 
     componentDidMount() {
-        const items = this.props.children;
-
-		if ( ! items || 0 === items.length ) {
-            this.setState({
-                empty: true
-            });
-        }
-
 		this.setState({
 			loading: this.props.loading
 		});
     }
 
     render() {
-        const { empty, loading } = this.state;
-        const { freeData } = this.props;
+        const { loading } = this.state;
 
-		const items = Children.map( this.props.children, item => (
+        const { freeData, children: configsList } = this.props,
+			isEmpty = ! configsList || 0 === configsList.length;
+
+		const items = Children.map( configsList, item => (
 			<PresetsAccordionItem
 				id={ item.props.id }
 				default={ item.props.default || false }
@@ -92,7 +86,7 @@ export class PresetsPage extends Component {
                         <p>{ this.props.description }</p>
                     )}
 
-                    { ! loading && empty && (
+                    { ! loading && isEmpty && (
                         <Notifications type="info">
                             <p>{ this.props.empty }</p>
                         </Notifications>
@@ -109,7 +103,7 @@ export class PresetsPage extends Component {
 					</div>
 				) }
 
-                { !empty && (
+                { ! isEmpty && (
                     <div
                         className="sui-accordion sui-accordion-flushed"
                         style={ {
@@ -142,8 +136,8 @@ export class PresetsPage extends Component {
                     <BoxFooter
                         display="block"
                         alignment="center"
-                        paddingTop={ empty ? 0 : 30 }
-                        border={ empty ? 0 : 1 }
+                        paddingTop={ isEmpty ? 0 : 30 }
+                        border={ isEmpty ? 0 : 1 }
                     >
                         <p className="sui-description">{ this.props.update }</p>
                     </BoxFooter>

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -8,25 +8,8 @@ import { Button } from '@wpmudev/react-button';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
 export class PresetsPage extends Component {
-    constructor( props ) {
-        super( props );
-
-        this.state = {
-            empty: false,
-            loading: true
-        }
-    }
-
-    componentDidMount() {
-		this.setState({
-			loading: this.props.loading
-		});
-    }
-
     render() {
-        const { loading } = this.state;
-
-        const { freeData, children: configsList } = this.props,
+        const { freeData, isLoading, children: configsList } = this.props,
 			isEmpty = ! configsList || 0 === configsList.length;
 
 		const items = Children.map( configsList, item => (
@@ -86,7 +69,7 @@ export class PresetsPage extends Component {
                         <p>{ this.props.description }</p>
                     )}
 
-                    { ! loading && isEmpty && (
+                    { ! isLoading && isEmpty && (
                         <Notifications type="info">
                             <p>{ this.props.empty }</p>
                         </Notifications>
@@ -94,7 +77,7 @@ export class PresetsPage extends Component {
 
                 </BoxBody>
 
-				{ loading && (
+				{ isLoading && (
 					<div>
 						<span>
 							<span className="sui-icon-loader" aria-hidden="true"></span>

--- a/packages/shared-presets/lib/containers/shared-presets-widget.js
+++ b/packages/shared-presets/lib/containers/shared-presets-widget.js
@@ -1,95 +1,90 @@
-import React, { Component, Children } from 'react';
+import React, { Children } from 'react';
 import { Box, BoxHeader, BoxBody, BoxFooter } from '@wpmudev/react-box';
 import { Notifications } from '@wpmudev/react-notifications';
 import { Button } from '@wpmudev/react-button';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
-export class PresetsWidget extends Component {
-    render() {
-        const { isLoading, children: configsList } = this.props,
-			isEmpty = ! configsList || 0 === configsList.length;
+export const PresetsWidget = ( { isLoading, children: configsList, ...props } ) => {
+	const isEmpty = ! configsList || 0 === configsList.length;
 
-        const items = Children.map( configsList, item => {
-            return (
-                <PresetsAccordionItem
-                    default={ item.props.default || false }
-                    title={ item.props.title }
-                    description={ item.props.description }
-                    image={ item.props.image }
-                    applyLabel={ item.props.applyLabel }
-                    applyAction={ item.props.applyAction }
-                    downloadLabel={ item.props.downloadLabel }
-                    editLabel={ item.props.editLabel }
-                    editAction={ item.props.editAction }
-                    deleteLabel={ item.props.deleteLabel }
-                >
-                    { item.props.children }
-                </PresetsAccordionItem>
-            );
-        });
+	const items = Children.map( configsList, item => (
+		<PresetsAccordionItem
+			default={ item.props.default || false }
+			title={ item.props.title }
+			description={ item.props.description }
+			image={ item.props.image }
+			applyLabel={ item.props.applyLabel }
+			applyAction={ item.props.applyAction }
+			downloadLabel={ item.props.downloadLabel }
+			editLabel={ item.props.editLabel }
+			editAction={ item.props.editAction }
+			deleteLabel={ item.props.deleteLabel }
+		>
+			{ item.props.children }
+		</PresetsAccordionItem>
+	) );
 
-        return (
-            <Box>
+	return (
+		<Box>
 
-                { ! isLoading && ! isEmpty && (
-                    <BoxHeader
-                        titleIcon="wrench-tool"
-                        title={ this.props.title }
-                        tagLabel={ this.props.children.length }
-                    />
-                )}
+			{ ! isLoading && ! isEmpty && (
+				<BoxHeader
+					titleIcon="wrench-tool"
+					title={ props.title }
+					tagLabel={ configsList.length }
+				/>
+			)}
 
-                { isEmpty && (
-                    <BoxHeader
-                        titleIcon="wrench-tool"
-                        title={ this.props.title }
-                    />
-                )}
+			{ isEmpty && (
+				<BoxHeader
+					titleIcon="wrench-tool"
+					title={ props.title }
+				/>
+			)}
 
-                <BoxBody>
+			<BoxBody>
 
-                    <p>{ this.props.message }</p>
+				<p>{ props.message }</p>
 
-                    { ! isLoading && isEmpty && (
-                        <Notifications type="info">
-                            <p>{ this.props.notice }</p>
-                        </Notifications>
-                    )}
+				{ ! isLoading && isEmpty && (
+					<Notifications type="info">
+						<p>{ props.notice }</p>
+					</Notifications>
+				)}
 
-                </BoxBody>
+			</BoxBody>
 
-				{ isLoading && (
-					<div>
-						<span>
-							<span className="sui-icon-loader" aria-hidden="true"></span>
-							{ this.props.loadingLabel }
-						</span>
-					</div>
-				) }
+			{ isLoading && (
+				<div>
+					<span>
+						<span className="sui-icon-loader" aria-hidden="true"></span>
+						{ props.loadingLabel }
+					</span>
+				</div>
+			) }
 
-                { ! isEmpty && (
-                    <div
-                        className="sui-accordion sui-accordion-flushed"
-                        style={ { borderBottom: 0 } }
-                    >
-                        { items }
-                    </div>
-                )}
+			{ ! isEmpty && (
+				<div
+					className="sui-accordion sui-accordion-flushed"
+					style={ { borderBottom: 0 } }
+				>
+					{ items }
+				</div>
+			)}
 
-                <BoxFooter>
-                    <Button
-                        icon="save"
-                        label="Save Config"
-                        color="blue"
-                    />
-                    <Button
-                        icon="wrench-tool"
-                        label="Manage Configs"
-                        design="ghost"
-                    />
-                </BoxFooter>
+			<BoxFooter>
+				<Button
+					icon="save"
+					label="Save Config"
+					color="blue"
+				/>
+				<Button
+					icon="wrench-tool"
+					label="Manage Configs"
+					design="ghost"
+				/>
+			</BoxFooter>
 
-            </Box>
-        );
-    }
+		</Box>
+	);
 }

--- a/packages/shared-presets/lib/containers/shared-presets-widget.js
+++ b/packages/shared-presets/lib/containers/shared-presets-widget.js
@@ -5,24 +5,8 @@ import { Button } from '@wpmudev/react-button';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
 export class PresetsWidget extends Component {
-    constructor( props ) {
-        super( props );
-
-        this.state = {
-			loading: true,
-        }
-    }
-
-    componentDidMount() {
-		this.setState({
-			loading: this.props.loading
-		});
-    }
-
     render() {
-        const { loading } = this.state;
-
-        const { children: configsList } = this.props,
+        const { isLoading, children: configsList } = this.props,
 			isEmpty = ! configsList || 0 === configsList.length;
 
         const items = Children.map( configsList, item => {
@@ -47,7 +31,7 @@ export class PresetsWidget extends Component {
         return (
             <Box>
 
-                { ! loading && ! isEmpty && (
+                { ! isLoading && ! isEmpty && (
                     <BoxHeader
                         titleIcon="wrench-tool"
                         title={ this.props.title }
@@ -66,7 +50,7 @@ export class PresetsWidget extends Component {
 
                     <p>{ this.props.message }</p>
 
-                    { ! loading && isEmpty && (
+                    { ! isLoading && isEmpty && (
                         <Notifications type="info">
                             <p>{ this.props.notice }</p>
                         </Notifications>
@@ -74,7 +58,7 @@ export class PresetsWidget extends Component {
 
                 </BoxBody>
 
-				{ loading && (
+				{ isLoading && (
 					<div>
 						<span>
 							<span className="sui-icon-loader" aria-hidden="true"></span>

--- a/packages/shared-presets/lib/containers/shared-presets-widget.js
+++ b/packages/shared-presets/lib/containers/shared-presets-widget.js
@@ -9,29 +9,23 @@ export class PresetsWidget extends Component {
         super( props );
 
         this.state = {
-            empty: false,
 			loading: true,
         }
     }
 
     componentDidMount() {
-        const items = this.props.children;
-
-        if ( ! items || 0 === items.length ) {
-            this.setState({
-                empty: true
-            });
-        }
-
 		this.setState({
 			loading: this.props.loading
 		});
     }
 
     render() {
-        const { empty, loading } = this.state;
+        const { loading } = this.state;
 
-        const items = Children.map( this.props.children, item => {
+        const { children: configsList } = this.props,
+			isEmpty = ! configsList || 0 === configsList.length;
+
+        const items = Children.map( configsList, item => {
             return (
                 <PresetsAccordionItem
                     default={ item.props.default || false }
@@ -53,7 +47,7 @@ export class PresetsWidget extends Component {
         return (
             <Box>
 
-                { ! loading && ! empty && (
+                { ! loading && ! isEmpty && (
                     <BoxHeader
                         titleIcon="wrench-tool"
                         title={ this.props.title }
@@ -61,7 +55,7 @@ export class PresetsWidget extends Component {
                     />
                 )}
 
-                { empty && (
+                { isEmpty && (
                     <BoxHeader
                         titleIcon="wrench-tool"
                         title={ this.props.title }
@@ -72,7 +66,7 @@ export class PresetsWidget extends Component {
 
                     <p>{ this.props.message }</p>
 
-                    { ! loading && empty && (
+                    { ! loading && isEmpty && (
                         <Notifications type="info">
                             <p>{ this.props.notice }</p>
                         </Notifications>
@@ -89,7 +83,7 @@ export class PresetsWidget extends Component {
 					</div>
 				) }
 
-                { !empty && (
+                { ! isEmpty && (
                     <div
                         className="sui-accordion sui-accordion-flushed"
                         style={ { borderBottom: 0 } }


### PR DESCRIPTION
Presets don't change their inner state. We could let the parent component handle the state and pass the data as preset's properties.

Also, converting the presets from classes to functional components because there's no use in them being classes.