### PR TITLE
✨ new(shared-presets): Handle modals within the component.

### DIFF
--- a/packages/shared-compiler/lib/shared-compiler.js
+++ b/packages/shared-compiler/lib/shared-compiler.js
@@ -39,7 +39,8 @@ const inputOptions = {
 	],
 	external: [
 		'react',
-		'styled-components'
+		'styled-components',
+		'@justfixnyc/react-aria-modal'
 	]
 };
 

--- a/packages/shared-presets/docs/presets-page-free.stories.js
+++ b/packages/shared-presets/docs/presets-page-free.stories.js
@@ -148,6 +148,16 @@ primary.argTypes = {
 			strings: {},
 		},
 	},
+	editModalData: {
+		defaultValue: {
+			action: ( config, formData, setErrorMessage, closeModal ) => {
+				const message = config ? 'Editing config ' + config.name : 'Creating new config';
+				console.log( message );
+				closeModal();
+			},
+			strings: {},
+		},
+	},
     configsList: {
         defaultValue: [
             {
@@ -157,7 +167,6 @@ primary.argTypes = {
                 description: 'Recommended performance config for every site.',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
-				editAction: () => console.log( 'Editing config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
             {
@@ -166,7 +175,6 @@ primary.argTypes = {
                 description: 'Lazy Load, CDN, Super-Smush, PNG to JPEG Conversion, Image Resizing',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
-				editAction: () => console.log( 'Editing config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
         ]

--- a/packages/shared-presets/docs/presets-page-free.stories.js
+++ b/packages/shared-presets/docs/presets-page-free.stories.js
@@ -8,19 +8,32 @@ export default {
 
 const Template = ({ children, ...args }) => {
     return (
-        <PresetsPage {...args}>
-            { children && children.map( ( child, index ) => (
-                <div key={ index } { ...child }>
-                    <div name="Lazy Load" status="Active" />
-                    <div name="CDN" status="Active" />
-                    <div name="Super-Smush" status="Active" />
-                    <div name="PNG to JPEG Conversion" status="Active" />
-                    <div name="Image Resizing" status="Active" />
-                </div>
-            ) ) }
-        </PresetsPage>
+        <PresetsPage {...args} />
     );
 };
+
+const defaultConfig = [
+	{
+		label: 'Lazy Load',
+		value: 'Active',
+	},
+	{
+		label: 'CDN',
+		value: 'Active',
+	},
+	{
+		label: 'Super-Smush',
+		value: 'Inactive',
+	},
+	{
+		label: 'PNG to JPEG',
+		value: 'Inactive',
+	},
+	{
+		label: 'Image Resizing',
+		value: 'Active',
+	},
+];
 
 export const primary = Template.bind({});
 primary.storyName = "Default"
@@ -116,7 +129,7 @@ primary.argTypes = {
 	saveNewConfig: {
 		defaultValue: () => console.log( 'Saving new config' ),
 	},
-    children: {
+    configsList: {
         defaultValue: [
             {
 				id: 1,
@@ -124,6 +137,7 @@ primary.argTypes = {
                 name: 'Basic Config',
                 description: 'Recommended performance config for every site.',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
+				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
 				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),
@@ -134,6 +148,7 @@ primary.argTypes = {
                 name: 'designtest.com / JAN / 2021',
                 description: 'Lazy Load, CDN, Super-Smush, PNG to JPEG Conversion, Image Resizing',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
+				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
 				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),

--- a/packages/shared-presets/docs/presets-page-free.stories.js
+++ b/packages/shared-presets/docs/presets-page-free.stories.js
@@ -129,6 +129,16 @@ primary.argTypes = {
 	saveNewConfig: {
 		defaultValue: () => console.log( 'Saving new config' ),
 	},
+	applyModalData: {
+		defaultValue: {
+			action: ( configId, closeModal ) => {
+				console.log( 'Applying config ' + configId );
+				closeModal();
+			},
+			strings: {},
+		},
+
+	},
     configsList: {
         defaultValue: [
             {
@@ -139,7 +149,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
@@ -150,7 +159,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },

--- a/packages/shared-presets/docs/presets-page-free.stories.js
+++ b/packages/shared-presets/docs/presets-page-free.stories.js
@@ -131,13 +131,22 @@ primary.argTypes = {
 	},
 	applyModalData: {
 		defaultValue: {
-			action: ( configId, closeModal ) => {
-				console.log( 'Applying config ' + configId );
+			action: ( config, closeModal ) => {
+				console.log( 'Applying config ' + config.name );
 				closeModal();
 			},
 			strings: {},
 		},
 
+	},
+	deleteModalData: {
+		defaultValue: {
+			action: ( config, closeModal ) => {
+				console.log( 'Deleting config ' + config.name );
+				closeModal();
+			},
+			strings: {},
+		},
 	},
     configsList: {
         defaultValue: [
@@ -149,7 +158,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
             {
@@ -159,7 +167,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
         ]

--- a/packages/shared-presets/docs/presets-page-free.stories.js
+++ b/packages/shared-presets/docs/presets-page-free.stories.js
@@ -126,9 +126,6 @@ primary.argTypes = {
             type: 'object'
         }
     },
-	saveNewConfig: {
-		defaultValue: () => console.log( 'Saving new config' ),
-	},
 	applyModalData: {
 		defaultValue: {
 			action: ( config, closeModal ) => {

--- a/packages/shared-presets/docs/presets-page-pro.stories.js
+++ b/packages/shared-presets/docs/presets-page-pro.stories.js
@@ -8,21 +8,34 @@ export default {
     parameters: {}
 }
 
-const Template = ({ children, settings, ...args }) => {
+const Template = ({ settings, ...args }) => {
     return (
-        <PresetsPage {...args}>
-            { children.map( ( child, index ) => (
-                <div key={ index } { ...child }>
-                    <div name="Lazy Load" status="Active" />
-                    <div name="CDN" status="Active" />
-                    <div name="Super-Smush" status="Active" />
-                    <div name="PNG to JPEG Conversion" status="Active" />
-                    <div name="Image Resizing" status="Active" />
-                </div>
-            ) ) }
-        </PresetsPage>
+        <PresetsPage {...args} />
     );
 };
+
+const defaultConfig = [
+	{
+		label: 'Lazy Load',
+		value: 'Active',
+	},
+	{
+		label: 'CDN',
+		value: 'Active',
+	},
+	{
+		label: 'Super-Smush',
+		value: 'Inactive',
+	},
+	{
+		label: 'PNG to JPEG',
+		value: 'Inactive',
+	},
+	{
+		label: 'Image Resizing',
+		value: 'Active',
+	},
+];
 
 export const primary = Template.bind({});
 primary.storyName = "Default"
@@ -107,7 +120,7 @@ primary.argTypes = {
 	saveNewConfig: {
 		defaultValue: () => console.log( 'Saving new config' ),
 	},
-    children: {
+    configsList: {
         defaultValue: [
             {
 				id: 1,
@@ -115,6 +128,7 @@ primary.argTypes = {
                 name: 'Basic Config',
                 description: 'Recommended performance config for every site.',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
+				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
 				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),
@@ -125,6 +139,7 @@ primary.argTypes = {
                 name: 'designtest.com / JAN / 2021',
                 description: 'Lazy Load, CDN, Super-Smush, PNG to JPEG Conversion, Image Resizing',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
+				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
 				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),

--- a/packages/shared-presets/docs/presets-page-pro.stories.js
+++ b/packages/shared-presets/docs/presets-page-pro.stories.js
@@ -122,13 +122,22 @@ primary.argTypes = {
 	},
 	applyModalData: {
 		defaultValue: {
-			action: ( configId, closeModal ) => {
-				console.log( 'Applying config ' + configId );
+			action: ( config, closeModal ) => {
+				console.log( 'Applying config ' + config.name );
 				closeModal();
 			},
 			strings: {},
 		},
 
+	},
+	deleteModalData: {
+		defaultValue: {
+			action: ( config, closeModal ) => {
+				console.log( 'Deleting config ' + config.name );
+				closeModal();
+			},
+			strings: {},
+		},
 	},
     configsList: {
         defaultValue: [
@@ -140,7 +149,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
             {
@@ -150,7 +158,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
         ]

--- a/packages/shared-presets/docs/presets-page-pro.stories.js
+++ b/packages/shared-presets/docs/presets-page-pro.stories.js
@@ -139,6 +139,16 @@ primary.argTypes = {
 			strings: {},
 		},
 	},
+	editModalData: {
+		defaultValue: {
+			action: ( config, formData, setErrorMessage, closeModal ) => {
+				const message = config ? 'Editing config ' + config.name : 'Creating new config';
+				console.log( message );
+				closeModal();
+			},
+			strings: {},
+		},
+	},
     configsList: {
         defaultValue: [
             {
@@ -148,7 +158,6 @@ primary.argTypes = {
                 description: 'Recommended performance config for every site.',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
-				editAction: () => console.log( 'Editing config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
             {
@@ -157,7 +166,6 @@ primary.argTypes = {
                 description: 'Lazy Load, CDN, Super-Smush, PNG to JPEG Conversion, Image Resizing',
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
-				editAction: () => console.log( 'Editing config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
         ]

--- a/packages/shared-presets/docs/presets-page-pro.stories.js
+++ b/packages/shared-presets/docs/presets-page-pro.stories.js
@@ -117,9 +117,6 @@ primary.argTypes = {
             type: 'object'
         }
     },
-	saveNewConfig: {
-		defaultValue: () => console.log( 'Saving new config' ),
-	},
 	applyModalData: {
 		defaultValue: {
 			action: ( config, closeModal ) => {

--- a/packages/shared-presets/docs/presets-page-pro.stories.js
+++ b/packages/shared-presets/docs/presets-page-pro.stories.js
@@ -120,6 +120,16 @@ primary.argTypes = {
 	saveNewConfig: {
 		defaultValue: () => console.log( 'Saving new config' ),
 	},
+	applyModalData: {
+		defaultValue: {
+			action: ( configId, closeModal ) => {
+				console.log( 'Applying config ' + configId );
+				closeModal();
+			},
+			strings: {},
+		},
+
+	},
     configsList: {
         defaultValue: [
             {
@@ -130,7 +140,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },
@@ -141,7 +150,6 @@ primary.argTypes = {
                 image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 				config: defaultConfig,
 				editAction: () => console.log( 'Editing config' ),
-				applyAction: () => console.log( 'Applying config' ),
 				deleteAction: () => console.log( 'Deleting config' ),
 				downloadAction: () => console.log( 'Downloading config' ),
             },

--- a/packages/shared-presets/docs/presets-widget.stories.js
+++ b/packages/shared-presets/docs/presets-widget.stories.js
@@ -42,7 +42,6 @@ primary.args = {
 	saveLabel: 'Save Configs',
 	manageLabel: 'Manage Configs',
     emptyNotice: 'You don’t have any available config. Save preset configurations of Smush’s settings, then upload and apply them to your other sites in just a few clicks!',
-    saveNewConfig: () => console.log( 'Saving new config' ),
 	manageConfigsUrl: '#',
 	configsList: [
         {
@@ -51,9 +50,6 @@ primary.args = {
             description: 'Recommended performance config for every site.',
             image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 			config: defaultConfig,
-			editAction: () => console.log( 'Editing config' ),
-			applyAction: () => console.log( 'Applying config' ),
-			deleteAction: () => console.log( 'Deleting config' ),
 			downloadAction: () => console.log( 'Downloading config' ),
         },
         {
@@ -62,12 +58,31 @@ primary.args = {
             description: 'Donec ullamcorper nulla non metus auctor fringilla.',
             image: 'https://pbs.twimg.com/profile_images/671394755951984640/GSkxXgDp_400x400.png',
 			config: defaultConfig,
-			editAction: () => console.log( 'Editing config' ),
-			applyAction: () => console.log( 'Applying config' ),
-			deleteAction: () => console.log( 'Deleting config' ),
 			downloadAction: () => console.log( 'Downloading config' ),
         }
     ],
+	applyModalData: {
+		action: ( config, closeModal ) => {
+			console.log( 'Applying config ' + config.name );
+			closeModal();
+		},
+		strings: {},
+	},
+	deleteModalData: {
+		action: ( config, closeModal ) => {
+			console.log( 'Deleting config ' + config.name );
+			closeModal();
+		},
+		strings: {},
+	},
+	editModalData: {
+		action: ( config, formData, setErrorMessage, closeModal ) => {
+			const message = config ? 'Editing config ' + config.name : 'Creating new config';
+			console.log( message );
+			closeModal();
+		},
+		strings: {},
+	},
 };
 
 export const secondary = Template.bind({});

--- a/packages/shared-presets/lib/components/accordion-item.js
+++ b/packages/shared-presets/lib/components/accordion-item.js
@@ -93,7 +93,7 @@ export class PresetsAccordionItem extends Component {
 
 	accordionHeadApplyClicked = ( e ) => {
 		e.stopPropagation();
-		this.props.applyAction( this.props.id );
+		this.props.applyAction();
 	}
 
     render() {
@@ -137,7 +137,7 @@ export class PresetsAccordionItem extends Component {
                         <div
                             name={ this.props.applyLabel || 'Apply' }
                             icon="check"
-                            onClick={ () => applyAction( this.props.id ) }
+                            onClick={ applyAction }
                         />
                         <div
                             name={ this.props.downloadLabel || 'Download' }

--- a/packages/shared-presets/lib/components/accordion-item.js
+++ b/packages/shared-presets/lib/components/accordion-item.js
@@ -147,7 +147,7 @@ export class PresetsAccordionItem extends Component {
                         <div
                             name={ this.props.editLabel || 'Name and Description' }
                             icon="pencil"
-                            onClick={ () => editAction( this.props.id ) }
+                            onClick={ editAction }
                         />
                         <div
                             name={ this.props.deleteLabel || 'Delete' }

--- a/packages/shared-presets/lib/components/accordion-item.js
+++ b/packages/shared-presets/lib/components/accordion-item.js
@@ -153,7 +153,7 @@ export class PresetsAccordionItem extends Component {
                             name={ this.props.deleteLabel || 'Delete' }
                             icon="trash"
                             color="red"
-                            onClick={ () => deleteAction( this.props.id ) }
+                            onClick={ deleteAction }
                         />
                     </Dropdown>
                 </AccordionItemHeaderAlt>

--- a/packages/shared-presets/lib/components/apply-modal.js
+++ b/packages/shared-presets/lib/components/apply-modal.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * SUI dependencies
+ */
+import { Modal } from '@wpmudev/react-modal';
+import { ButtonIcon } from '@wpmudev/react-button-icon';
+import { Button } from '@wpmudev/react-button';
+
+const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
+	const {
+		closeIcon = 'Close this dialog window',
+		title = 'Apply Config',
+		description = 'Are you sure you want to apply the {configName} settings config to this site? We recommend you have a backup available as your existing settings configuration will be overridden.',
+		cancelButton = 'Cancel',
+		actionButton = 'Apply',
+	} = strings;
+
+	const [isSaving, setIsSaving] = React.useState(false);
+
+	const requestCallback = () => {
+		setOpen(false);
+	};
+
+	const doAction = () => {
+		setIsSaving(true);
+		save(config.id, requestCallback);
+	};
+
+	const modalContent = () => (
+		<div className="sui-box">
+			<div className="sui-box-header sui-flatten sui-content-center sui-spacing-top--60">
+				<ButtonIcon
+					label={ closeIcon }
+					icon="close"
+					iconSize="md"
+					className="sui-button-float--right"
+					onClick={() => setOpen(false)}
+				/>
+				<h2 id="smush-config-edit-title">
+					{ title }
+				</h2>
+				<p className="sui-description">
+					{ description }
+				</p>
+			</div>
+			<div className="sui-box-footer sui-content-center sui-flatten sui-spacing-top--0 sui-spacing-bottom--60">
+				<Button
+					design="ghost"
+					label={ cancelButton }
+					onClick={() => setOpen(false)}
+				/>
+				<Button
+					color="blue"
+					icon="check"
+					label={ actionButton }
+					onClick={doAction}
+					loading={isSaving}
+				/>
+			</div>
+		</div>
+	);
+
+	return (
+		<Modal
+			mounted={true}
+			dialogId="smush-configs-apply-modal"
+			titleId="smush-config-apply-title"
+			size="sm"
+			modalContent={modalContent}
+		/>
+	);
+};
+
+export default ApplyModal;

--- a/packages/shared-presets/lib/components/apply-modal.js
+++ b/packages/shared-presets/lib/components/apply-modal.js
@@ -19,15 +19,15 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 		actionButton = 'Apply',
 	} = strings;
 
-	const [isSaving, setIsSaving] = React.useState(false);
+	const [ isSaving, setIsSaving ] = React.useState( false );
 
 	const requestCallback = () => {
-		setOpen(false);
+		setOpen( false );
 	};
 
 	const doAction = () => {
-		setIsSaving(true);
-		save(config.id, requestCallback);
+		setIsSaving( true );
+		save( config.id, requestCallback );
 	};
 
 	const modalContent = () => (
@@ -38,7 +38,7 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 					icon="close"
 					iconSize="md"
 					className="sui-button-float--right"
-					onClick={() => setOpen(false)}
+					onClick={ () => setOpen( false ) }
 				/>
 				<h2 id="smush-config-edit-title">
 					{ title }
@@ -51,14 +51,14 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 				<Button
 					design="ghost"
 					label={ cancelButton }
-					onClick={() => setOpen(false)}
+					onClick={ () => setOpen(false) }
 				/>
 				<Button
 					color="blue"
 					icon="check"
 					label={ actionButton }
-					onClick={doAction}
-					loading={isSaving}
+					onClick={ doAction }
+					loading={ isSaving }
 				/>
 			</div>
 		</div>
@@ -66,11 +66,11 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 
 	return (
 		<Modal
-			mounted={true}
+			mounted={ true }
 			dialogId="smush-configs-apply-modal"
 			titleId="smush-config-apply-title"
 			size="sm"
-			modalContent={modalContent}
+			modalContent={ modalContent }
 		/>
 	);
 };

--- a/packages/shared-presets/lib/components/apply-modal.js
+++ b/packages/shared-presets/lib/components/apply-modal.js
@@ -14,7 +14,7 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 	const {
 		closeIcon = 'Close this dialog window',
 		title = 'Apply Config',
-		description = 'Are you sure you want to apply the {configName} settings config to this site? We recommend you have a backup available as your existing settings configuration will be overridden.',
+		description = 'Are you sure you want to apply the {configName} config to this site? We recommend you have a backup available as your existing settings configuration will be overridden.',
 		cancelButton = 'Cancel',
 		actionButton = 'Apply',
 	} = strings;
@@ -44,7 +44,7 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 					{ title }
 				</h2>
 				<p className="sui-description">
-					{ description }
+					{ description.replace( '{configName}', config.name) }
 				</p>
 			</div>
 			<div className="sui-box-footer sui-content-center sui-flatten sui-spacing-top--0 sui-spacing-bottom--60">

--- a/packages/shared-presets/lib/components/apply-modal.js
+++ b/packages/shared-presets/lib/components/apply-modal.js
@@ -21,13 +21,13 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 
 	const [ isSaving, setIsSaving ] = React.useState( false );
 
-	const requestCallback = () => {
+	const closeModal = () => {
 		setOpen( false );
 	};
 
 	const doAction = () => {
 		setIsSaving( true );
-		save( config, requestCallback );
+		save( config, closeModal );
 	};
 
 	const modalContent = () => (
@@ -40,7 +40,7 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 					className="sui-button-float--right"
 					onClick={ () => setOpen( false ) }
 				/>
-				<h2 id="smush-config-edit-title">
+				<h2 id="sui-config-edit-title">
 					{ title }
 				</h2>
 				<p className="sui-description">
@@ -51,7 +51,7 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 				<Button
 					design="ghost"
 					label={ cancelButton }
-					onClick={ () => setOpen(false) }
+					onClick={ () => setOpen( false ) }
 				/>
 				<Button
 					color="blue"
@@ -67,8 +67,8 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 	return (
 		<Modal
 			mounted={ true }
-			dialogId="smush-configs-apply-modal"
-			titleId="smush-config-apply-title"
+			dialogId="sui-configs-apply-modal"
+			titleId="sui-config-apply-title"
 			size="sm"
 			modalContent={ modalContent }
 		/>

--- a/packages/shared-presets/lib/components/apply-modal.js
+++ b/packages/shared-presets/lib/components/apply-modal.js
@@ -27,7 +27,7 @@ const ApplyModal = ({ setOpen, config, save, strings = {} }) => {
 
 	const doAction = () => {
 		setIsSaving( true );
-		save( config.id, requestCallback );
+		save( config, requestCallback );
 	};
 
 	const modalContent = () => (

--- a/packages/shared-presets/lib/components/delete-modal.js
+++ b/packages/shared-presets/lib/components/delete-modal.js
@@ -14,7 +14,7 @@ const DeleteModal = ( { setOpen, config, save, strings = {} } ) => {
 	const {
 		closeIcon = 'Close this dialog window',
 		title = 'Delete Configuration File',
-		description = 'Are you sure you want to delete the {configName} file? You will no longer be able to apply it to this or other connected sites.',
+		description = 'Are you sure you want to delete {configName}? You will no longer be able to apply it to this or other connected sites.',
 		cancelButton = 'Cancel',
 		actionButton = 'Delete',
 	} = strings;
@@ -44,7 +44,7 @@ const DeleteModal = ( { setOpen, config, save, strings = {} } ) => {
 					{ title }
 				</h2>
 				<p className="sui-description">
-					{ description }
+					{ description.replace( '{configName}', config.name) }
 				</p>
 			</div>
 			<div className="sui-box-footer sui-content-center sui-flatten sui-spacing-top--0 sui-spacing-bottom--60">

--- a/packages/shared-presets/lib/components/delete-modal.js
+++ b/packages/shared-presets/lib/components/delete-modal.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * SUI dependencies
+ */
+import { Modal } from '@wpmudev/react-modal';
+import { ButtonIcon } from '@wpmudev/react-button-icon';
+import { Button } from '@wpmudev/react-button';
+
+const DeleteModal = ( { setOpen, config, save, strings = {} } ) => {
+	const {
+		closeIcon = 'Close this dialog window',
+		title = 'Delete Configuration File',
+		description = 'Are you sure you want to delete the {configName} file? You will no longer be able to apply it to this or other connected sites.',
+		cancelButton = 'Cancel',
+		actionButton = 'Delete',
+	} = strings;
+
+	const [ isSaving, setIsSaving ] = React.useState( false );
+
+	const closeModal = () => {
+		setOpen( false );
+	};
+
+	const doAction = () => {
+		setIsSaving( true );
+		save( config, closeModal );
+	};
+
+	const modalContent = () => (
+		<div className="sui-box">
+			<div className="sui-box-header sui-flatten sui-content-center sui-spacing-top--60">
+				<ButtonIcon
+					label={ closeIcon }
+					icon="close"
+					iconSize="md"
+					className="sui-button-float--right"
+					onClick={ () => setOpen( false ) }
+				/>
+				<h2 id="smush-config-delete-title">
+					{ title }
+				</h2>
+				<p className="sui-description">
+					{ description }
+				</p>
+			</div>
+			<div className="sui-box-footer sui-content-center sui-flatten sui-spacing-top--0 sui-spacing-bottom--60">
+				<Button
+					design="ghost"
+					label={ cancelButton }
+					onClick={ () => setOpen(false) }
+				/>
+				<Button
+					color="red"
+					label={ actionButton }
+					onClick={ doAction }
+					loading={ isSaving }
+				/>
+			</div>
+		</div>
+	);
+
+	return (
+		<Modal
+			mounted={ true }
+			dialogId="sui-configs-delete-modal"
+			titleId="sui-config-delete-title"
+			size="sm"
+			modalContent={ modalContent }
+		/>
+	);
+};
+
+export default DeleteModal;

--- a/packages/shared-presets/lib/components/edit-modal.js
+++ b/packages/shared-presets/lib/components/edit-modal.js
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * SUI dependencies
+ */
+import { Modal } from '@wpmudev/react-modal';
+import { ButtonIcon } from '@wpmudev/react-button-icon';
+import { Button } from '@wpmudev/react-button';
+import { Input } from '@wpmudev/react-input';
+
+const EditModal = ( { setOpen, config, save, strings = {} } ) => {
+	const configName = config ? config.name : '',
+		configDescription = config ? config.description : '';
+
+	const [ nameValue, setNameValue ] = React.useState( configName );
+	const [ descriptionValue, setDescriptionValue ] = React.useState( configDescription );
+	const [ errorMessage, setErrorMessage ] = React.useState( false );
+	const [ isSaving, setIsSaving ] = React.useState( false );
+
+	const {
+		closeIcon = 'Close this dialog window',
+		nameInput = 'Config name',
+		descriptionInput = 'Description',
+		emptyNameError = 'The config name is required',
+		actionButton = 'Save',
+		cancelButton = 'Cancel',
+		editTitle = 'Rename Config',
+		editDescription = 'Change your config name to something recognizable.',
+		createTitle = 'Save Config',
+		createDescription = 'Save your current settings configuration. You’ll be able to then download and apply it to your other sites.'
+	} = strings;
+
+	const closeModal = () => {
+		setOpen( false );
+	};
+
+	const displayErrorMessage = ( message ) => {
+		setErrorMessage( message );
+		setIsSaving( false );
+	};
+
+	const doAction = () => {
+		if ( ! nameValue.trim().length ) {
+			setErrorMessage( emptyNameError );
+			return;
+		}
+
+		setErrorMessage( false );
+		setIsSaving( true );
+
+		const data = new FormData();
+		data.append( 'name', nameValue );
+		data.append( 'description', descriptionValue );
+
+		save( config, data, displayErrorMessage, closeModal );
+	};
+
+	const modalContent = () => {
+		// If a config is provided, we're editing a config. We're saving a new one otherwise.
+		const title = config ? editTitle : createTitle,
+			description = config ? editDescription : createDescription;
+
+		return (
+			<div className="sui-box">
+				<div className="sui-box-header sui-flatten sui-content-center sui-spacing-top--60">
+					<ButtonIcon
+						label={ closeIcon }
+						icon="close"
+						iconSize="md"
+						className="sui-button-float--right"
+						onClick={ () => setOpen( false ) }
+					/>
+					<h2 id="sui-config-edit-title">{ title }</h2>
+					<p className="sui-description">{ description }</p>
+				</div>
+				<div className="sui-box-body">
+					<div
+						role="alert"
+						id="configs-edit-modal-error-message"
+						className="sui-notice sui-notice-error"
+						aria-live="assertive"
+						style={ { display: errorMessage ? 'block' : '' } }
+					>
+						{ errorMessage && (
+							<div className="sui-notice-content">
+								<div className="sui-notice-message">
+									<span
+										className="sui-notice-icon sui-icon-info sui-md"
+										aria-hidden="true"
+									></span>
+									<p>{ errorMessage }</p>
+								</div>
+							</div>
+						) }
+					</div>
+
+					<Input
+						label={ nameInput }
+						name="name"
+						value={ nameValue }
+						onChange={ ( e ) => setNameValue( e.target.value ) }
+					/>
+					<div className="sui-form-field">
+						<label
+							className="sui-label"
+							htmlFor="sui-edit-config-textarea"
+						>
+							{ descriptionInput }
+						</label>
+						<textarea
+							id="sui-edit-config-textarea"
+							className="sui-form-control"
+							name="description"
+							value={ descriptionValue }
+							onChange={ ( e ) => setDescriptionValue( e.target.value ) }
+						/>
+					</div>
+				</div>
+				<div className="sui-box-footer sui-content-separated sui-flatten sui-spacing-top--0">
+					<Button
+						design="ghost"
+						label={ cancelButton }
+						onClick={ () => setOpen( false ) }
+					/>
+					<Button
+						color="blue"
+						icon="save"
+						label={ actionButton }
+						onClick={ doAction }
+						loading={ isSaving }
+					/>
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<Modal
+			mounted={ true }
+			dialogId="sui-configs-edit-modal"
+			titleId="sui-config-edit-title"
+			size="sm"
+			modalContent={ modalContent }
+		/>
+	);
+};
+
+export default EditModal;

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -7,6 +7,7 @@ import { Button } from '@wpmudev/react-button';
 
 import ApplyModal from '../components/apply-modal';
 import DeleteModal from '../components/delete-modal';
+import EditModal from '../components/edit-modal';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
 const LoadingContent = styled.div`
@@ -41,10 +42,19 @@ const LoadingMask = styled.div`
 }
 `;
 
-export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData, deleteModalData, ...props } ) => {
+export const PresetsPage = ( {
+	configsList,
+	applyModalData,
+	deleteModalData,
+	editModalData,
+	freeData,
+	isLoading,
+	...props
+} ) => {
 	const [ currentConfig, setCurrentConfig ] = React.useState( null );
 	const [ isApplyOpen, setIsApplyOpen ] = React.useState( false );
 	const [ isDeleteOpen, setIsDeleteOpen ] = React.useState( false );
+	const [isEditOpen, setIsEditOpen] = React.useState( false );
 
 	const isEmpty = ! configsList || 0 === configsList.length;
 
@@ -55,6 +65,8 @@ export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData,
 			setIsApplyOpen( true );
 		} else if ( 'delete' === action ) {
 			setIsDeleteOpen( true );
+		} else {
+			setIsEditOpen( true );
 		}
 	};
 
@@ -81,7 +93,7 @@ export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData,
 							downloadLabel={ item.downloadLabel }
 							downloadAction={ item.downloadAction }
 							editLabel={ item.editLabel }
-							editAction={ item.editAction }
+							editAction={ () => openModal( 'edit', item ) }
 							deleteLabel={ item.deleteLabel }
 							deleteAction={ () => openModal( 'delete', item ) }
 						>
@@ -155,7 +167,7 @@ export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData,
 							icon="save"
 							label={ props.saveLabel || 'Save Config' }
 							color="blue"
-							onClick={ props.saveNewConfig }
+							onClick={ () => openModal( 'edit', null ) }
 						/>
 					</div>
 				</BoxHeader>
@@ -216,6 +228,14 @@ export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData,
 					config={ currentConfig }
 					save={ deleteModalData.action }
 					strings={deleteModalData.strings}
+				/>
+			) }
+			{ isEditOpen && (
+				<EditModal
+					setOpen={ setIsEditOpen }
+					config={ currentConfig }
+					save={ editModalData.action }
+					strings={editModalData.strings}
 				/>
 			) }
 		</React.Fragment>

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -1,5 +1,4 @@
-import React, { Children } from 'react';
-import { device, utils } from '../components/utils';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Box, BoxHeader, BoxBody, BoxFooter } from '@wpmudev/react-box';
@@ -39,29 +38,8 @@ const LoadingMask = styled.div`
 }
 `;
 
-export const PresetsPage = ( { freeData, isLoading, children: configsList, ...props } ) => {
+export const PresetsPage = ( { freeData, isLoading, configsList, ...props } ) => {
 	const isEmpty = ! configsList || 0 === configsList.length;
-
-	const items = Children.map( configsList, item => (
-		<PresetsAccordionItem
-			id={ item.props.id }
-			default={ item.props.default || false }
-			name={ item.props.name }
-			description={ item.props.description }
-			image={ item.props.image }
-			showApplyButton={true}
-			applyLabel={ item.props.applyLabel }
-			applyAction={ item.props.applyAction }
-			downloadLabel={ item.props.downloadLabel }
-			downloadAction={ item.props.downloadAction }
-			editLabel={ item.props.editLabel }
-			editAction={ item.props.editAction }
-			deleteLabel={ item.props.deleteLabel }
-			deleteAction={ item.props.deleteAction }
-		>
-			{ item.props.children }
-		</PresetsAccordionItem>
-	) );
 
 	const Table = (
 		<React.Fragment>
@@ -72,7 +50,29 @@ export const PresetsPage = ( { freeData, isLoading, children: configsList, ...pr
 						borderBottomWidth: 0
 					} }
 				>
-					{ items }
+					{ configsList.map( item => (
+						<PresetsAccordionItem
+							key={ item.id }
+							id={ item.id }
+							default={ item.default || false }
+							name={ item.name }
+							description={ item.description }
+							image={ item.image }
+							showApplyButton={ true }
+							applyLabel={ item.applyLabel }
+							applyAction={ item.applyAction }
+							downloadLabel={ item.downloadLabel }
+							downloadAction={ item.downloadAction }
+							editLabel={ item.editLabel }
+							editAction={ item.editAction }
+							deleteLabel={ item.deleteLabel }
+							deleteAction={ item.deleteAction }
+						>
+							{ item.config.map( ( item, index ) => (
+								<div key={ index } name={ item.label } status={ item.value } />
+							) ) }
+						</PresetsAccordionItem>
+					) ) }
 				</div>
 			)}
 		</React.Fragment>

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import { Box, BoxHeader, BoxBody, BoxFooter } from '@wpmudev/react-box';
 import { Notifications } from '@wpmudev/react-notifications';
 import { Button } from '@wpmudev/react-button';
+
+import ApplyModal from '../components/apply-modal';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
 const LoadingContent = styled.div`
@@ -38,8 +40,19 @@ const LoadingMask = styled.div`
 }
 `;
 
-export const PresetsPage = ( { freeData, isLoading, configsList, ...props } ) => {
+export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData, ...props } ) => {
+	const [currentConfig, setCurrentConfig] = React.useState(null);
+	const [isApplyOpen, setIsApplyOpen] = React.useState(false);
+
 	const isEmpty = ! configsList || 0 === configsList.length;
+
+	const openModal = (action, config) => {
+		setCurrentConfig(config);
+
+		if ('apply' === action) {
+			setIsApplyOpen(true);
+		}
+	};
 
 	const Table = (
 		<React.Fragment>
@@ -60,7 +73,7 @@ export const PresetsPage = ( { freeData, isLoading, configsList, ...props } ) =>
 							image={ item.image }
 							showApplyButton={ true }
 							applyLabel={ item.applyLabel }
-							applyAction={ item.applyAction }
+							applyAction={ () => openModal( 'apply', item ) }
 							downloadLabel={ item.downloadLabel }
 							downloadAction={ item.downloadAction }
 							editLabel={ item.editLabel }
@@ -114,75 +127,85 @@ export const PresetsPage = ( { freeData, isLoading, configsList, ...props } ) =>
 	);
 
 	return (
-		<Box>
+		<React.Fragment>
+			<Box>
+				<BoxHeader title={ props.title }>
+					<div>
+						<Button
+							icon="upload-cloud"
+							label={ props.uploadLabel || 'Upload' }
+							design="ghost"
+							htmlFor="sui-upload-configs-input"
+						/>
+						<input
+							id="sui-upload-configs-input"
+							type="file"
+							name="config_file"
+							className="sui-hidden"
+							value=""
+							readOnly="readonly"
+							onChange={ props.uploadConfig }
+							accept=".json"
+						/>
+						<Button
+							icon="save"
+							label={ props.saveLabel || 'Save Config' }
+							color="blue"
+							onClick={ props.saveNewConfig }
+						/>
+					</div>
+				</BoxHeader>
 
-			<BoxHeader title={ props.title }>
-				<div>
-					<Button
-						icon="upload-cloud"
-						label={ props.uploadLabel || 'Upload' }
-						design="ghost"
-						htmlFor="sui-upload-configs-input"
-					/>
-					<input
-						id="sui-upload-configs-input"
-						type="file"
-						name="config_file"
-						className="sui-hidden"
-						value=""
-						readOnly="readonly"
-						onChange={ props.uploadConfig }
-						accept=".json"
-					/>
-					<Button
-						icon="save"
-						label={ props.saveLabel || 'Save Config' }
-						color="blue"
-						onClick={ props.saveNewConfig }
-					/>
-				</div>
-			</BoxHeader>
+				<BoxBody>
 
-			<BoxBody>
+					{ props.description && (
+						<p>{ props.description }</p>
+					)}
 
-				{ props.description && (
-					<p>{ props.description }</p>
+					{ !isLoading && isEmpty && (
+						<Notifications type="info">
+							<p>{ props.emptyNotice }</p>
+						</Notifications>
+					)}
+
+				</BoxBody>
+
+				{ isLoading && (
+					<LoadingContent>
+						<LoadingWrap aria-hidden="true">
+							{ Table }
+							{ Footer }
+						</LoadingWrap>
+						<LoadingMask>
+							<p className="sui-description">
+								<span
+									className="sui-icon-loader sui-loading"
+									aria-hidden="true"
+									style={ { marginRight: 10 } }
+								/>
+								{ props.loadingText }
+							</p>
+						</LoadingMask>
+					</LoadingContent>
 				)}
 
-				{ !isLoading && isEmpty && (
-					<Notifications type="info">
-						<p>{ props.emptyNotice }</p>
-					</Notifications>
-				)}
-
-			</BoxBody>
-
-			{ isLoading && (
-				<LoadingContent>
-					<LoadingWrap aria-hidden="true">
+				{ !isLoading && (
+					<React.Fragment>
 						{ Table }
 						{ Footer }
-					</LoadingWrap>
-					<LoadingMask>
-						<p className="sui-description">
-							<span
-								className="sui-icon-loader sui-loading"
-								aria-hidden="true"
-								style={ { marginRight: 10 } }
-							/>
-							{ props.loadingText }
-						</p>
-					</LoadingMask>
-				</LoadingContent>
-			)}
+					</React.Fragment>
+				)}
 
-			{ !isLoading && (
-				<React.Fragment>
-					{ Table }
-					{ Footer }
-				</React.Fragment>
-			)}
+			</Box>
 
-		</Box>
+			{ isApplyOpen && (
+				<ApplyModal
+					setOpen={setIsApplyOpen}
+					config={currentConfig}
+					save={applyModalData.action}
+					strings={applyModalData.strings}
+				/>
+			) }
+		</React.Fragment>
 	);
 }

--- a/packages/shared-presets/lib/containers/shared-presets-page.js
+++ b/packages/shared-presets/lib/containers/shared-presets-page.js
@@ -6,6 +6,7 @@ import { Notifications } from '@wpmudev/react-notifications';
 import { Button } from '@wpmudev/react-button';
 
 import ApplyModal from '../components/apply-modal';
+import DeleteModal from '../components/delete-modal';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
 const LoadingContent = styled.div`
@@ -40,17 +41,20 @@ const LoadingMask = styled.div`
 }
 `;
 
-export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData, ...props } ) => {
-	const [currentConfig, setCurrentConfig] = React.useState(null);
-	const [isApplyOpen, setIsApplyOpen] = React.useState(false);
+export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData, deleteModalData, ...props } ) => {
+	const [ currentConfig, setCurrentConfig ] = React.useState( null );
+	const [ isApplyOpen, setIsApplyOpen ] = React.useState( false );
+	const [ isDeleteOpen, setIsDeleteOpen ] = React.useState( false );
 
 	const isEmpty = ! configsList || 0 === configsList.length;
 
-	const openModal = (action, config) => {
-		setCurrentConfig(config);
+	const openModal = ( action, config ) => {
+		setCurrentConfig( config );
 
-		if ('apply' === action) {
-			setIsApplyOpen(true);
+		if ( 'apply' === action ) {
+			setIsApplyOpen( true );
+		} else if ( 'delete' === action ) {
+			setIsDeleteOpen( true );
 		}
 	};
 
@@ -79,7 +83,7 @@ export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData,
 							editLabel={ item.editLabel }
 							editAction={ item.editAction }
 							deleteLabel={ item.deleteLabel }
-							deleteAction={ item.deleteAction }
+							deleteAction={ () => openModal( 'delete', item ) }
 						>
 							{ item.config.map( ( item, index ) => (
 								<div key={ index } name={ item.label } status={ item.value } />
@@ -204,6 +208,14 @@ export const PresetsPage = ( { freeData, isLoading, configsList, applyModalData,
 					config={currentConfig}
 					save={applyModalData.action}
 					strings={applyModalData.strings}
+				/>
+			) }
+			{ isDeleteOpen && (
+				<DeleteModal
+					setOpen={ setIsDeleteOpen }
+					config={ currentConfig }
+					save={ deleteModalData.action }
+					strings={deleteModalData.strings}
 				/>
 			) }
 		</React.Fragment>

--- a/packages/shared-presets/lib/containers/shared-presets-widget.js
+++ b/packages/shared-presets/lib/containers/shared-presets-widget.js
@@ -2,85 +2,139 @@ import React from 'react';
 import { Box, BoxHeader, BoxBody, BoxFooter } from '@wpmudev/react-box';
 import { Notifications } from '@wpmudev/react-notifications';
 import { Button } from '@wpmudev/react-button';
+
+import ApplyModal from '../components/apply-modal';
+import DeleteModal from '../components/delete-modal';
+import EditModal from '../components/edit-modal';
 import { PresetsAccordionItem } from '../components/accordion-item';
 
-export const PresetsWidget = ( { configsList, ...props } ) => {
+export const PresetsWidget = ( {
+	configsList,
+	applyModalData,
+	deleteModalData,
+	editModalData,
+	...props
+} ) => {
+	const [ currentConfig, setCurrentConfig ] = React.useState( null );
+	const [ isApplyOpen, setIsApplyOpen ] = React.useState( false );
+	const [ isDeleteOpen, setIsDeleteOpen ] = React.useState( false );
+	const [ isEditOpen, setIsEditOpen ] = React.useState( false );
+
 	const isEmpty = ! configsList || 0 === configsList.length;
 
+	const openModal = ( action, config ) => {
+		setCurrentConfig( config );
+
+		if ( 'apply' === action ) {
+			setIsApplyOpen( true );
+		} else if ( 'delete' === action ) {
+			setIsDeleteOpen( true );
+		} else {
+			setIsEditOpen( true );
+		}
+	};
+
 	return (
-		<Box>
+		<React.Fragment>
+			<Box>
 
-			{ ! isEmpty && (
-				<BoxHeader
-					titleIcon="wrench-tool"
-					title={ props.title }
-					tagLabel={ configsList.length }
-				/>
-			)}
-
-			{ isEmpty && (
-				<BoxHeader
-					titleIcon="wrench-tool"
-					title={ props.title }
-				/>
-			)}
-
-			<BoxBody>
-
-				<p>{ props.description }</p>
-
-				{ isEmpty && (
-					<Notifications type="info">
-						<p>{ props.emptyNotice }</p>
-					</Notifications>
+				{ ! isEmpty && (
+					<BoxHeader
+						titleIcon="wrench-tool"
+						title={ props.title }
+						tagLabel={ configsList.length }
+					/>
 				)}
 
-			</BoxBody>
+				{ isEmpty && (
+					<BoxHeader
+						titleIcon="wrench-tool"
+						title={ props.title }
+					/>
+				)}
 
-			{ !isEmpty && (
-				<div
-					className="sui-accordion sui-accordion-flushed"
-					style={ { borderBottom: 0 } }
-				>
-					{ configsList.map( item => (
-						<PresetsAccordionItem
-							key={ item.id }
-							default={ item.default || false }
-							name={ item.name }
-							description={ item.description }
-							image={ item.image }
-							applyLabel={ item.applyLabel }
-							applyAction={ item.applyAction }
-							downloadLabel={ item.downloadLabel }
-							downloadAction={ item.downloadAction }
-							editLabel={ item.editLabel }
-							editAction={ item.editAction }
-							deleteLabel={ item.deleteLabel }
-							deleteAction={ item.deleteAction }
-						>
-							{ item.config.map( ( item, index ) => (
-								<div key={ index } name={ item.label } status={ item.value } />
-							) ) }
-						</PresetsAccordionItem>
-					) ) }
-				</div>
-			)}
+				<BoxBody>
 
-			<BoxFooter>
-				<Button
-					icon="save"
-					label={ props.saveLabel }
-					color="blue"
-					onClick={ props.saveNewConfig }
+					<p>{ props.description }</p>
+
+					{ isEmpty && (
+						<Notifications type="info">
+							<p>{ props.emptyNotice }</p>
+						</Notifications>
+					)}
+
+				</BoxBody>
+
+				{ !isEmpty && (
+					<div
+						className="sui-accordion sui-accordion-flushed"
+						style={ { borderBottom: 0 } }
+					>
+						{ configsList.map( item => (
+							<PresetsAccordionItem
+								key={ item.id }
+								default={ item.default || false }
+								name={ item.name }
+								description={ item.description }
+								image={ item.image }
+								applyLabel={ item.applyLabel }
+								applyAction={ () => openModal( 'apply', item ) }
+								downloadLabel={ item.downloadLabel }
+								downloadAction={ item.downloadAction }
+								editLabel={ item.editLabel }
+								editAction={ () => openModal( 'edit', item ) }
+								deleteLabel={ item.deleteLabel }
+								deleteAction={ () => openModal( 'delete', item ) }
+							>
+								{ item.config.map( ( item, index ) => (
+									<div key={ index } name={ item.label } status={ item.value } />
+								) ) }
+							</PresetsAccordionItem>
+						) ) }
+					</div>
+				)}
+
+				<BoxFooter>
+					<Button
+						icon="save"
+						label={ props.saveLabel }
+						color="blue"
+						onClick={ () => openModal( 'edit', null ) }
+					/>
+					<Button
+						icon="wrench-tool"
+						label={ props.manageLabel }
+						design="ghost"
+						href={ props.manageConfigsUrl }
+					/>
+				</BoxFooter>
+
+			</Box>
+
+			{ isApplyOpen && (
+				<ApplyModal
+					setOpen={setIsApplyOpen}
+					config={currentConfig}
+					save={applyModalData.action}
+					strings={applyModalData.strings}
 				/>
-				<Button
-					icon="wrench-tool"
-					label={ props.manageLabel }
-					design="ghost"
-					href={ props.manageConfigsUrl }
+			) }
+			{ isDeleteOpen && (
+				<DeleteModal
+					setOpen={ setIsDeleteOpen }
+					config={ currentConfig }
+					save={ deleteModalData.action }
+					strings={deleteModalData.strings}
 				/>
-			</BoxFooter>
-
-		</Box>
+			) }
+			{ isEditOpen && (
+				<EditModal
+					setOpen={ setIsEditOpen }
+					config={ currentConfig }
+					save={ editModalData.action }
+					strings={editModalData.strings}
+				/>
+			) }
+		</React.Fragment>
 	);
 }

--- a/packages/shared-presets/package.json
+++ b/packages/shared-presets/package.json
@@ -41,6 +41,7 @@
     "@wpmudev/react-button": "^1.0.8",
     "@wpmudev/react-button-icon": "^1.1.0",
     "@wpmudev/react-dropdown": "^1.1.3",
+    "@wpmudev/react-input": "^1.0.4",
     "@wpmudev/react-modal": "^1.0.3",
     "@wpmudev/react-notifications": "^1.0.8",
     "styled-components": "^5.2.3"

--- a/packages/shared-presets/package.json
+++ b/packages/shared-presets/package.json
@@ -41,6 +41,7 @@
     "@wpmudev/react-button": "^1.0.8",
     "@wpmudev/react-button-icon": "^1.1.0",
     "@wpmudev/react-dropdown": "^1.1.3",
+    "@wpmudev/react-modal": "^1.0.3",
     "@wpmudev/react-notifications": "^1.0.8",
     "styled-components": "^5.2.3"
   },


### PR DESCRIPTION
With this PR, the presets component will handle all of the modals (Delete confirmation, apply confirmation, and save/edit). The plugins only need to provide the translatable strings, the "loading" status, and the callbacks to perform on each action.