### PR TITLE
🐛 fix(shared-presets): Add '@justfixyc/react-aria-modal' as a dependency

### DIFF
--- a/packages/shared-presets/package.json
+++ b/packages/shared-presets/package.json
@@ -36,6 +36,7 @@
     "react": "^17.0.2"
   },
   "dependencies": {
+	"@justfixnyc/react-aria-modal": "^5.1.3-alpha.0",
     "@wordpress/api-fetch": "^4.0.0",
     "@wpmudev/react-accordion": "^1.0.4",
     "@wpmudev/react-box": "^1.2.4",


### PR DESCRIPTION
Some plugins aren't getting this dependency installed for some reason. This is a workaround so we can move forward with the development while we find out why that's happening.