### PR TITLE
fix(tutorials-list): Misaligned description when `reading time` is missing.

### DIFF
--- a/packages/shared-tutorials-list/package.json
+++ b/packages/shared-tutorials-list/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@wpmudev/react-notifications": "^1.0.1",
-    "@wpmudev/react-post": "^1.1.4",
+    "@wpmudev/react-post": "^1.1.5",
     "styled-components": "^5.2.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4433,6 +4433,13 @@
   dependencies:
     styled-components "^5.3.0"
 
+"@wpmudev/react-post@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@wpmudev/react-post/-/react-post-1.1.5.tgz#b84d15ca075216579d6b14dd6b2c0e2446c4ade3"
+  integrity sha512-ezrc+MaZ/YEuEZRRoOum3Rv4BSf5JVRTglee0wCsko9S200N6DFc+KLvAn/7F/VDnfZlLY50Ya6YuGfQuGwzcA==
+  dependencies:
+    styled-components "^5.3.0"
+
 "@wpmudev/shared-notifications-offer@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@wpmudev/shared-notifications-offer/-/shared-notifications-offer-1.0.0.tgz#440b1aa9e054d52baa2a9ada21160936d98df5ac"


### PR DESCRIPTION
Upgrading to latest (v1.1.5) version of [@wpmudev/react-post/](https://www.npmjs.com/package/@wpmudev/react-post/v/1.1.5) package. This version contains a fix for the misaligned description.