### PR TITLE
fix(tutorials-slider): Misaligned description when `reading time` is missing.

### DIFF
--- a/packages/shared-tutorials-slider/package.json
+++ b/packages/shared-tutorials-slider/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@wpmudev/react-notifications": "^1.0.1",
-    "@wpmudev/react-post": "^1.1.4",
+    "@wpmudev/react-post": "^1.1.5",
     "styled-components": "^5.2.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4426,13 +4426,6 @@
   dependencies:
     "@wpmudev/react-button-icon" "^1.1.0"
 
-"@wpmudev/react-post@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@wpmudev/react-post/-/react-post-1.1.4.tgz#9be4177e67433a875dfde806895d8ef9af69d45d"
-  integrity sha512-fd5rTCy95vr8HeyRjrQ53u/djQz3DZNAE4WqMklOHxjqvAd0dZIVF3X71En3uTPhzxgLUe0mYXTgKuGF1x6zmg==
-  dependencies:
-    styled-components "^5.3.0"
-
 "@wpmudev/react-post@^1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@wpmudev/react-post/-/react-post-1.1.5.tgz#b84d15ca075216579d6b14dd6b2c0e2446c4ade3"


### PR DESCRIPTION
Upgrading to latest (v1.1.5) version of [@wpmudev/react-post/](https://www.npmjs.com/package/@wpmudev/react-post/v/1.1.5)[](https://github.com/iamleigh) package. This version contains a fix for the misaligned description on posts.