### PR TITLE
fix(tutorials-slider): Upgrade `dependencies` to its latest versions.

### DIFF
--- a/packages/shared-tutorials-slider/package.json
+++ b/packages/shared-tutorials-slider/package.json
@@ -48,7 +48,7 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@wpmudev/react-notifications": "^1.0.1",
+    "@wpmudev/react-notifications": "^1.0.8",
     "@wpmudev/react-post": "^1.1.5",
     "styled-components": "^5.3.3"
   },

--- a/packages/shared-tutorials-slider/package.json
+++ b/packages/shared-tutorials-slider/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/wpmudev/shared-modules#readme",
   "devDependencies": {
     "@wpmudev/shared-compiler": "^1.0.0",
-    "react": "^17.0.1"
+    "react": "^17.0.2"
   },
   "dependencies": {
     "@wpmudev/react-notifications": "^1.0.1",

--- a/packages/shared-tutorials-slider/package.json
+++ b/packages/shared-tutorials-slider/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@wpmudev/react-notifications": "^1.0.1",
     "@wpmudev/react-post": "^1.1.5",
-    "styled-components": "^5.2.1"
+    "styled-components": "^5.3.3"
   },
   "resolutions": {
     "styled-components": "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14327,7 +14327,7 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@^5.2.1, styled-components@^5.2.3, styled-components@^5.3.0:
+styled-components@^5.2.1, styled-components@^5.2.3, styled-components@^5.3.0, styled-components@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.3.tgz#312a3d9a549f4708f0fb0edc829eb34bde032743"
   integrity sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==


### PR DESCRIPTION
Upgrade component dependencies to the latest version that can support without breaking.