### PR TITLE
fix(presets): Break each config setting status in a new line.

### DIFF
--- a/packages/shared-presets/lib/components/table.js
+++ b/packages/shared-presets/lib/components/table.js
@@ -1,73 +1,71 @@
-import React, { Component, Children } from 'react';
-import styled from 'styled-components';
+import React, { Component, Children } from "react";
+import styled from "styled-components";
 
 const Table = styled.table`
-[class*="sui-2-"] .sui-wrap && {
-	width: 100%;
-	margin: 0;
-	border-spacing: 0;
-	border-collapse: collapse;
-	table-layout: fixed;
+	[class*="sui-2-"] .sui-wrap && {
+		width: 100%;
+		margin: 0;
+		border-spacing: 0;
+		border-collapse: collapse;
+		table-layout: fixed;
 
-	tbody {
-
-		tr {
-
-			&:nth-child(2n+2) {
-				background-color: #f8f8f8;
-			}
-		}
-
-		td {
-			padding: 9px;
-			vertical-align: center;
-			color: #888;
-			font: 500 13px/22px "Roboto", sans-serif;
-			letter-spacing: -0.25px;
-
-			div {
-				overflow: hidden;
-				display: -webkit-box;
-				text-overflow: ellipsis;
-				-webkit-line-clamp: 2;
-				-webkit-box-orient: vertical
+		tbody {
+			tr {
+				&:nth-child(2n + 2) {
+					background-color: #f8f8f8;
+				}
 			}
 
-			&:first-child {
-				width: 45%;
-				padding-left: 20px;
-				color: #333;
-			}
+			td {
+				padding: 9px;
+				vertical-align: center;
+				color: #888;
+				font: 500 13px/22px "Roboto", sans-serif;
+				letter-spacing: -0.25px;
 
-			&:last-child {
-				width: 55%;
-				padding-right: 20px;
-				white-space: pre-wrap;
+				div {
+					overflow: hidden;
+					display: -webkit-box;
+					text-overflow: ellipsis;
+					-webkit-line-clamp: 2;
+					-webkit-box-orient: vertical;
+				}
+
+				&:first-child {
+					width: 45%;
+					padding-left: 20px;
+					color: #333;
+				}
+
+				&:last-child {
+					width: 55%;
+					padding-right: 20px;
+					white-space: pre-wrap;
+				}
 			}
 		}
 	}
-}
 `;
 
 export class PresetsTable extends Component {
-    constructor( props ) {
-        super( props );
-    }
+	constructor(props) {
+		super(props);
+	}
 
-    render() {
-        const rows = Children.map( this.props.children, row => {
+	render() {
+		const rows = Children.map(this.props.children, (row) => {
 			return (
 				<tr>
-					<td>{ row.props.name }</td>
-					<td>{ row.props.status }</td>
+					<td>{row.props.name}</td>
+					<td>{row.props.status}</td>
 				</tr>
 			);
 		});
 
-        return (
-            <Table {...this.props}>
-                <tbody>{rows}</tbody>
-            </Table>
-        );
-    }
-};
+		return (
+			<Table {...this.props}>
+				<tbody>{rows}</tbody>
+			</Table>
+		);
+	}
+}

--- a/packages/shared-presets/lib/components/table.js
+++ b/packages/shared-presets/lib/components/table.js
@@ -54,10 +54,14 @@ export class PresetsTable extends Component {
 
 	render() {
 		const rows = Children.map(this.props.children, (row) => {
+			const rowName = row.props.name;
+			const rowStatus = row.props.status;
+			const rowContent = rowStatus[0].replace(/( - )/g, "\n");
+
 			return (
 				<tr>
-					<td>{row.props.name}</td>
-					<td>{row.props.status}</td>
+					<td>{rowName}</td>
+					<td>{rowContent}</td>
 				</tr>
 			);
 		});


### PR DESCRIPTION
Each preset lists the saved configurations, although, for some reason, the data returned for those configurations is a list of settings in a single array but separated by a middle dash icon. To solve that problem and make the settings more readable for the users, this PR introduces a solution with regex replacing the dash with line breaks.