### PR TITLE
Set pre-release version for shared-notifications-banner

### DIFF
--- a/packages/shared-modules/package.json
+++ b/packages/shared-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmudev/shared-modules",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "WPMU DEV Shared Modules",
   "author": "WPMU DEV",
   "contributors": [

--- a/packages/shared-notifications-banner/package.json
+++ b/packages/shared-notifications-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmudev/shared-notifications-banner",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "WPMU DEV Shared Banner Notification",
   "keywords": [],
   "author": "WPMU DEV (https://premium.wpmudev.org/)",


### PR DESCRIPTION
This PR reverts versions for shared-modules from 1.4.1 to 1.4.0 and shared-notifications-banner form 1.0.0 to 0.0.0